### PR TITLE
Mise à jour de actions/setup-python à la v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       id: python_version_check
       run: echo ::set-output name=PYTHON_VERSION::$(cat .python-version)
     - name: Installation Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "${{ steps.python_version_check.outputs.PYTHON_VERSION }}"
     - name: Cache pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       id: python_version_check
       run: echo ::set-output name=PYTHON_VERSION::$(cat .python-version)
     - name: Installation Python
-      uses: actions/setup-python@v2.2
+      uses: actions/setup-python@v2
       with:
         python-version: "${{ steps.python_version_check.outputs.PYTHON_VERSION }}"
     - name: Cache pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       id: python_version_check
       run: echo ::set-output name=PYTHON_VERSION::$(cat .python-version)
     - name: Installation Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2
       with:
         python-version: "${{ steps.python_version_check.outputs.PYTHON_VERSION }}"
     - name: Cache pip


### PR DESCRIPTION
Précédemment, lorsque Python 3.9.5 sortait, la version précédente 3.9.4 n'était pas accessible.

L'action `setup-python` a entre temps évolué pour gérer ce cas correctement, ce qui nous permet de nous appuyer sur le fichier `.python-version` directement, en garantissant ainsi qu'on utilise la même version en local.

Voir https://github.com/etalab/schema-comptage-velo/issues/2 pour le problème équivalent.